### PR TITLE
fix: BPA ICGC use a mix of uppercase and lowercase for danger levels

### DIFF
--- a/src/bpa_icgc.py
+++ b/src/bpa_icgc.py
@@ -126,7 +126,9 @@ def danger_levels_from_bpa(bpa_file: str) -> list:
                         if zone.replace(" ", "") == elem.replace(" ", "")
                     ]
                     danger_levels += [
-                        level for level in AVALANCHE_LEVELS if level in elem
+                        level
+                        for level in AVALANCHE_LEVELS
+                        if (level in elem or level.upper() in elem)
                     ]
 
                 # Check values


### PR DESCRIPTION
## Description

ICGC is using mixed lowercase and uppercase letters to define the danger level, so we need to control both options.

## Types of changes

- 🐞  Bugfix (non-breaking change which fixes an issue)
