### PR TITLE
fix: Error decoding date from Aran bpa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   November 2021
 #
 #################################################################
-FROM python:3.13
+FROM python:3.12
 LABEL maintainer="ntorrano@atesmaps.org"
 
 WORKDIR /

--- a/src/bpa_aran.py
+++ b/src/bpa_aran.py
@@ -76,9 +76,10 @@ def get_bpa_publication_date(bpa) -> str:
 
         print("Obtaining BPA report date...")
         bpa_date_container = bpa.body.find_all("div", attrs={"class": "bTitle"})[0].text
+        print(bpa_date_container)
         locale.setlocale(locale.LC_TIME, "ca_ES.UTF-8")  # Aran BPA is in Catalan
         bpa_date_obj = datetime.strptime(
-            bpa_date_container.split(",")[1].strip(), "%d %B de %Y"
+            bpa_date_container.encode("latin1").decode("utf-8").split(",")[1].strip(), "%d %B de %Y"
         )
         bpa_date = bpa_date_obj.strftime("%Y-%m-%d")
 


### PR DESCRIPTION
## Description

- Aran BPA extractor has an encoding bug with the Catalan month `març` that needs to be re-encoded as UTF-8.
- `PyMuPDF ` is failing with Python 3.13 and the version has been downgraded to `Python 3.12`.

## Types of changes

- 🐞  Bugfix (non-breaking change which fixes an issue)
