### PR TITLE
fix: Update BPA_ANDORRA_URL to use HTTPS

### DIFF
--- a/src/bpa_urls.py
+++ b/src/bpa_urls.py
@@ -35,7 +35,7 @@ BPA_METEOFRANCE_URL = (
 BPA_METEOFRANCE_HISTORY_URL = "https://donneespubliques.meteofrance.fr/?fond=produit&id_produit=265&id_rubrique=50"
 
 # ----- ANDORRA ----- #
-BPA_ANDORRA_URL = "http://www.meteo.ad/estatneu"
+BPA_ANDORRA_URL = "https://www.meteo.ad/estatneu"
 
 # ----- ARAGON ----- #
 BPA_ARAGON_NAV_URL = "http://www.aemet.es/documentos/es/eltiempo/prediccion/montana/boletin_peligro_aludes/BPA_Pirineo_Nav_Ara.pdf"  # noqa: E501


### PR DESCRIPTION
## Description

This pull request updates the URL for the Andorra BPA data source to use HTTPS instead of HTTP in the `src/bpa_urls.py` file. This improves security and ensures encrypted connections to the data provider. 

* Changed `BPA_ANDORRA_URL` from `http://www.meteo.ad/estatneu` to `https://www.meteo.ad/estatneu` to use a secure HTTPS connection.

## Types of changes

- 🐞  Bugfix (non-breaking change which fixes an issue)
